### PR TITLE
Remove case when last digit is ommited

### DIFF
--- a/model_mommy/generators.py
+++ b/model_mommy/generators.py
@@ -77,7 +77,7 @@ def gen_float():
 
 def gen_decimal(max_digits, decimal_places):
     num_as_str = lambda x: ''.join([str(randint(0, 9)) for i in range(x)])
-    return Decimal("%s.%s" % (num_as_str(max_digits - decimal_places),
+    return Decimal("%s.%s" % (num_as_str(max_digits - decimal_places - 1),
                               num_as_str(decimal_places)))
 gen_decimal.required = ['max_digits', 'decimal_places']
 


### PR DESCRIPTION
In case of:
    amount = models.DecimalField(
        null=False,
        max_digits=16,
        decimal_places=2,
        blank=False,  
    )

Decimal(47461379535606.35)

converts to 

Decimal('47461379535606.4')

What is not the best situation for testing. It seems that Django thinks about "." as a symbol that included into max_digits.
